### PR TITLE
feat(button, interactionfeedback): add InteractionFeedback wrapper around Button

### DIFF
--- a/packages/hs-react-ui/src/components/Button/Button.stories.tsx
+++ b/packages/hs-react-ui/src/components/Button/Button.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { select, text, boolean, number, color } from '@storybook/addon-knobs';
+import { boolean, color, number, select, text } from '@storybook/addon-knobs';
 import { mdiMessage, mdiSend } from '@mdi/js';
 import { storiesOf } from '@storybook/react';
 
-import Button from './Button';
+import Button, { FeedbackTypes } from './Button';
 import colors from '../../enums/colors';
 import variants from '../../enums/variants';
 
@@ -28,6 +28,7 @@ storiesOf('Button', module).add(
         color={color('color', colors.primaryDark)}
         onClick={action('button-click')}
         disabled={boolean('disabled', false)}
+        feedbackType={select('feedbackType', FeedbackTypes, FeedbackTypes.simple)}
         isLoading={boolean('isLoading', false)}
         elevation={number('elevation', 1)}
         isProcessing={boolean('isProcessing', false)}

--- a/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -26,10 +26,6 @@ exports[`Button keeps the container the same when switching between isLoading an
   background-color: #707479;
 }
 
-.c0:active {
-  background-color: #63686c;
-}
-
 .c1 {
   background: linear-gradient( 45deg, rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75) ) repeat;
   background-size: 400% 100%;
@@ -84,10 +80,6 @@ exports[`Button keeps the container the same when switching between isLoading an
   background-color: #707479;
 }
 
-.c0:active {
-  background-color: #63686c;
-}
-
 <button
   class="c0"
   color="#7c8186"
@@ -123,10 +115,6 @@ exports[`Button shows ButtonContainer ButtonVariant.fill 1`] = `
 
 .c0:hover {
   background-color: #707479;
-}
-
-.c0:active {
-  background-color: #63686c;
 }
 
 <div>
@@ -166,10 +154,6 @@ exports[`Button shows ButtonContainer ButtonVariant.outline 1`] = `
   background-color: rgba(0,0,0,0.05);
 }
 
-.c0:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 <div>
   <button
     class="c0"
@@ -205,10 +189,6 @@ exports[`Button shows ButtonContainer ButtonVariant.text 1`] = `
 
 .c0:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c0:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 <div>
@@ -250,10 +230,6 @@ exports[`Button shows ButtonContainer with nondefault props variant and color 1`
   background-color: rgba(0,0,0,0.05);
 }
 
-.c0:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 <div>
   <button
     class="c0"
@@ -289,10 +265,6 @@ exports[`Button shows LeftIconContainer when isProcessing 1`] = `
 
 .c0:hover {
   background-color: #707479;
-}
-
-.c0:active {
-  background-color: #63686c;
 }
 
 .c1 {
@@ -361,10 +333,6 @@ exports[`Button shows icons 1`] = `
 
 .c0:hover {
   background-color: #707479;
-}
-
-.c0:active {
-  background-color: #63686c;
 }
 
 .c1 {
@@ -439,10 +407,6 @@ exports[`Button shows icons with type string 1`] = `
   background-color: #707479;
 }
 
-.c0:active {
-  background-color: #63686c;
-}
-
 .c1 {
   height: 1rem;
 }
@@ -515,10 +479,6 @@ exports[`Button shows loading text when provided 1`] = `
 
 .c0:hover {
   background-color: #707479;
-}
-
-.c0:active {
-  background-color: #63686c;
 }
 
 .c1 {

--- a/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -53,10 +53,6 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -184,10 +180,6 @@ exports[`Dropdown closes options when clicking outside 1`] = `
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c4 {
@@ -395,10 +387,6 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -521,10 +509,6 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c4 {
@@ -653,10 +637,6 @@ exports[`Dropdown displays all options when focused 1`] = `
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c4 {
@@ -864,10 +844,6 @@ exports[`Dropdown displays placeholder value on initial render 1`] = `
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -995,10 +971,6 @@ exports[`Dropdown does not display options on initial render 1`] = `
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1124,10 +1096,6 @@ exports[`Dropdown renders a value when given a matching option id through props 
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1246,10 +1214,6 @@ exports[`Dropdown renders no value when given a value that doesn't match any opt
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1362,10 +1326,6 @@ exports[`Dropdown renders one value when given two values but only one matches a
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c3 {
@@ -1484,10 +1444,6 @@ exports[`Dropdown renders two values when given matching option ids through prop
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c3 {
@@ -1612,10 +1568,6 @@ exports[`Dropdown renders two values when given matching option ids through prop
   background-color: rgba(0,0,0,0.05);
 }
 
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1736,10 +1688,6 @@ exports[`Dropdown selects options from values prop 1`] = `
 
 .c1:hover {
   background-color: rgba(0,0,0,0.05);
-}
-
-.c1:active {
-  background-color: rgba(0,0,0,0.1);
 }
 
 .c3 {

--- a/packages/hs-react-ui/src/components/InteractionFeedback/InteractionFeedback.stories.tsx
+++ b/packages/hs-react-ui/src/components/InteractionFeedback/InteractionFeedback.stories.tsx
@@ -37,7 +37,6 @@ storiesOf('InteractionFeedback', module).add(
       },
       'Circle fill',
     );
-    const fill = color('fillColor', colors.grayLight, 'Circle fill');
     const transitionProps = {
       enter: {
         r: `${number(
@@ -47,7 +46,6 @@ storiesOf('InteractionFeedback', module).add(
           'Circle radius',
         )}`,
         opacity: entranceOpacity,
-        fill,
       },
       from: {
         r: `${number(
@@ -57,12 +55,10 @@ storiesOf('InteractionFeedback', module).add(
           'Circle radius',
         )}`,
         opacity: entranceOpacity,
-        fill,
       },
       leave: {
-        r: '0',
+        r: `${number('Ending circle radius', 0, { range: true, min: 0, max: 100, step: 1}, 'Circle radius')}`,
         opacity: exitOpacity,
-        fill,
       },
       config: {
         mass: number('mass', 1, { range: true, min: 1, max: 10, step: 1 }, 'Circle physics'),
@@ -86,6 +82,7 @@ storiesOf('InteractionFeedback', module).add(
     };
     return (
       <InteractionFeedback
+        color={color('color', colors.grayDark, 'Circle fill')}
         interpolationFunctions={interpolationFunctions}
         transitionProps={transitionProps}
       >


### PR DESCRIPTION
Add two types of feedback to Button, simple (darkening by css), and ripple (utilizing
InteractionFeedback). Updated InteractionFeedback to take a color prop. This fill can still be
overridden by transitionProps.