### PR TITLE
fix(button and interactionfeedback): style the InteractionFeedback for the Button to inline-block

### DIFF
--- a/packages/hs-react-ui/src/components/Button/Button.tsx
+++ b/packages/hs-react-ui/src/components/Button/Button.tsx
@@ -118,6 +118,10 @@ const IconContainer = styled(Div)`
   vertical-align: middle;
 `;
 
+const StyledFeedbackContainer = styled(InteractionFeedback.Container)`
+  display: inline-block;
+`;
+
 const LeftIconContainer = styled(IconContainer)`
   ${({ hasContent }: { hasContent: boolean }) => `
     ${hasContent ? 'margin-right: 1em;' : ''}
@@ -202,6 +206,7 @@ const Button = ({
 
   return feedbackType === FeedbackTypes.ripple && !disabled ? (
     <InteractionFeedback
+      StyledContainer={StyledFeedbackContainer}
       color={getFontColorFromVariant(variant, containerColor)}
       {...(interactionFeedbackProps || {})}
     >

--- a/packages/hs-react-ui/src/components/InteractionFeedback/InteractionFeedback.tsx
+++ b/packages/hs-react-ui/src/components/InteractionFeedback/InteractionFeedback.tsx
@@ -104,6 +104,7 @@ const InteractionFeedback = ({
   );
 };
 
+InteractionFeedback.Container = Container;
 InteractionFeedback.defaultTransitionProps = defaultTransitionProps;
 InteractionFeedback.defaultInterpolationFunctions = defaultInterpolationFunctions;
 


### PR DESCRIPTION
Buttons are by default display: inline-block, but when the feedback type was set to "ripple" it was
wrapped in a div, setting them to display:block at the outer most layer
